### PR TITLE
Drop redundant dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "ember-cli-htmlbars": "^6.3.0"
   },
   "devDependencies": {
-    "@babel/core": "7.22.10",
     "@babel/eslint-parser": "7.22.15",
     "@babel/plugin-proposal-decorators": "7.22.15",
     "@ember/optional-features": "2.0.0",


### PR DESCRIPTION
It is already in the dependencies, no need to have it in devDependencies