### PR TITLE
Fix deprecation from @glimmer/syntax

### DIFF
--- a/ember-bem-helpers/lib/bem-ast-transform.cjs
+++ b/ember-bem-helpers/lib/bem-ast-transform.cjs
@@ -31,7 +31,11 @@ function isBlockName(statement) {
 }
 
 function isBem(statement) {
-  return statement.path.original === 'bem';
+  return (
+    (statement.type === 'MustacheStatement' ||
+      statement.type === 'SubExpression') &&
+    statement.path.original === 'bem'
+  );
 }
 
 function extractBlockName(statement) {

--- a/ember-bem-helpers/package.json
+++ b/ember-bem-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-bem-helpers",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "BEM helpers for Ember.js applications",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
`DEPRECATION: The original property on literal nodes is deprecated, use value instead`