### PR TITLE
Revert "Try to automerge a different way"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,7 @@
 {
   "extends": [
     "config:recommended",
-    ":preserveSemverRanges"
-  ],
-  "packageRules": [
-    {
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "pin",
-        "digest",
-        "lockFileMaintenance"
-      ],
-      "automerge": true
-    }
+    ":preserveSemverRanges",
+    ":automergeMinor"
   ]
 }


### PR DESCRIPTION
This reverts commit 083c11c0c82b414de60c7d3b8d45019b27a3134f. The built-in preset actually did work, but only for new renovate PRs, not existing ones.  :facepalm:

<img width="2560" alt="Screenshot 2025-04-18 at 10 24 39 AM (2)" src="https://github.com/user-attachments/assets/495a7f59-8c6e-422a-a56f-8de43ed3bb8a" />
