### PR TITLE
Fix missing workflow permissions in CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ concurrency:
 env:
   NODE_VERSION: 18
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Tests


### PR DESCRIPTION
Code scanning alerts[^1][^2][^3] revealed that this repo was using the default permissions (read/write) for all GitHub Actions workflows, which does not adhere to the principle of least privilege. This commit explicitly sets the permissions needed for the jobs in this workflow, which is to read the repository's contents.

[^1]:
https://github.com/retailnext/ember-bem-helpers/security/code-scanning/1
[^2]:
https://github.com/retailnext/ember-bem-helpers/security/code-scanning/2
[^3]:
https://github.com/retailnext/ember-bem-helpers/security/code-scanning/3