### PR TITLE
Remove brace-expansion pins

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
       "babel-plugin-module-resolver": "5.0.2",
       "cookie": "1.0.2",
       "package-json": "10.0.1",
-      "sane": "5.0.1",
-      "brace-expansion@<1.1.12": "^1.1.12",
-      "brace-expansion@>=2.0.0 <2.0.2": "^2.0.2"
+      "sane": "5.0.1"
     }
   },
   "homepage": "https://github.com/retailnext/ember-bem-helpers#readme",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,6 @@ overrides:
   cookie: 1.0.2
   package-json: 10.0.1
   sane: 5.0.1
-  brace-expansion@<1.1.12: ^1.1.12
-  brace-expansion@>=2.0.0 <2.0.2: ^2.0.2
 
 importers:
 


### PR DESCRIPTION
As [this article explains], to "force" an upgrade in a transitive
dependency to address a vulnerability, we should do it in three steps.
1. find the transitive dependency for the affected version
2. add an override in `package.json` for affected version
3. apply the change (`pnpm i`) to update the lockfile.

As part of step three, *the override should be removed only if the
affected dependency does not downgrade*. This implies that the "parent
dependencies" does not have a fixed version or a range that doesn't
include the target version. Removing the override after the dependency
is upgraded in our lockfiles helps keep our `package.json` "clean" and
prevents renovate from attempting unnecessary upgrades.

[this article explains]:
https://blog.logto.io/pnpm-upgrade-transitive-dependencies
