### PR TITLE
Revert "Temporarily disable release age check for `typescript-eslint`"

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,3 @@ overrides:
 autoInstallPeers: false
 allowBuilds:
   core-js: false
-minimumReleaseAgeExclude:
-  - '@typescript-eslint/*'
-  - 'typescript-eslint'


### PR DESCRIPTION
This reverts commit 3caf3d2ade32237c89edc2a50adbec2fcdfc51b7.