### PR TITLE
Improve NPM dependency cool downs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "extends": [
     "config:recommended",
     ":preserveSemverRanges",
-    ":automergeMinor"
+    ":automergeMinor",
+    "security:minimumReleaseAgeNpm"
   ],
   "labels": [
     "dependencies",


### PR DESCRIPTION
We're adopting renovate's [npm security preset] which enforces a cool
down of three days and prevents pull requests from being opened +
auto-merged until **after** the `minimumReleaseAge`. Security updates
main uninterrupted and are generally managed via dependabot.

[npm security preset]:
https://docs.renovatebot.com/presets-security/#securityminimumreleaseagenpm
