### PR TITLE
fix(security): patch tmp path traversal and qs DoS vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,8 @@ overrides:
   babel-plugin-module-resolver: 5.0.3
   cookie: 1.1.1
   package-json: 10.0.1
-  tmp: '>=0.2.4'
+  tmp: '>=0.2.6'
+  qs@>=6.11.1 <=6.15.1: '>=6.15.2'
   diff@<8.0.3: '>=8.0.3'
   serialize-javascript@<=7.0.2: '>=7.0.3'
   '@babel/runtime@<7.26.10': '>=7.26.10'
@@ -5053,12 +5054,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
-    engines: {node: '>=0.6'}
-
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -5771,8 +5768,8 @@ packages:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
@@ -9086,7 +9083,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.14.2
+      qs: 6.15.2
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -9101,7 +9098,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -9502,7 +9499,7 @@ snapshots:
       resolve-path: 1.4.0
       rimraf: 6.1.3
       sane: 5.0.1
-      tmp: 0.2.5
+      tmp: 0.2.7
       tree-sync: 2.1.0
       underscore.string: 3.3.6
       watch-detector: 1.0.2
@@ -9552,7 +9549,7 @@ snapshots:
 
   can-symlink@1.0.0:
     dependencies:
-      tmp: 0.2.5
+      tmp: 0.2.7
 
   caniuse-lite@1.0.30001778: {}
 
@@ -10889,7 +10886,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -10924,7 +10921,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -10939,7 +10936,7 @@ snapshots:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
-      tmp: 0.2.5
+      tmp: 0.2.7
 
   extract-stack@2.0.0: {}
 
@@ -11115,7 +11112,7 @@ snapshots:
   fixturify-project@1.10.0:
     dependencies:
       fixturify: 1.3.0
-      tmp: 0.2.5
+      tmp: 0.2.7
 
   fixturify@1.3.0:
     dependencies:
@@ -12588,11 +12585,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.14.2:
-    dependencies:
-      side-channel: 1.1.0
-
-  qs@6.15.0:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -13408,7 +13401,7 @@ snapshots:
       spawn-args: 0.2.0
       styled_string: 0.0.1
       tap-parser: 7.0.0
-      tmp: 0.2.5
+      tmp: 0.2.7
     transitivePeerDependencies:
       - arc-templates
       - atpl
@@ -13487,7 +13480,7 @@ snapshots:
       faye-websocket: 0.11.4
       livereload-js: 3.4.1
       object-assign: 4.1.1
-      qs: 6.15.0
+      qs: 6.15.2
     transitivePeerDependencies:
       - supports-color
 
@@ -13502,7 +13495,7 @@ snapshots:
     dependencies:
       tldts-core: 6.1.86
 
-  tmp@0.2.5: {}
+  tmp@0.2.7: {}
 
   tmpl@1.0.5: {}
 
@@ -13747,7 +13740,7 @@ snapshots:
     dependencies:
       heimdalljs-logger: 0.1.10
       silent-error: 1.1.1
-      tmp: 0.2.5
+      tmp: 0.2.7
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,8 @@ overrides:
   babel-plugin-module-resolver: 5.0.3
   cookie: 1.1.1
   package-json: 10.0.1
-  tmp: '>=0.2.4'
+  tmp: '>=0.2.6'
+  qs@>=6.11.1 <=6.15.1: '>=6.15.2'
   diff@<8.0.3: '>=8.0.3'
   serialize-javascript@<=7.0.2: '>=7.0.3'
   '@babel/runtime@<7.26.10': '>=7.26.10'


### PR DESCRIPTION
## Summary

Resolves two open Dependabot security alerts:

- **Alert #96 (high)** — `tmp < 0.2.6`: Path Traversal via unsanitized prefix/postfix that enables directory escape. Updated override from `>=0.2.4` → `>=0.2.6`; resolves to 0.2.7.
- **Alert #95 (medium)** — `qs >= 6.11.1, <= 6.15.1`: Remotely triggerable DoS — `qs.stringify` crashes with `TypeError` on null/undefined entries in comma-format arrays when `encodeValuesOnly` is set. Added new override pinning to `>=6.15.2`.

Both are transitive dependencies managed via `pnpm-workspace.yaml` overrides.

## Test plan

- [x] `pnpm install` completes successfully
- [x] `tmp` resolves to 0.2.7 in `pnpm-lock.yaml`
- [x] `qs` resolves to 6.15.2 in `pnpm-lock.yaml`
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)