### PR TITLE
fix(deps): resolve all open Dependabot alerts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,11 @@ settings:
 
 overrides:
   '@babel/runtime@<7.26.10': ^7.26.10
-  brace-expansion@<1.1.16: '>=1.1.16 <2'
-  brace-expansion@>=2.0.0 <2.1.2: '>=2.1.2 <3'
+  brace-expansion@<1.1.18: '>=1.1.18 <2'
+  brace-expansion@>=2.0.0 <2.1.4: '>=2.1.4 <3'
   brace-expansion@>=3.0.0 <5.0.8: '>=5.0.8'
+  js-yaml@>=4.0.0 <4.3.1: ^4.3.1
+  socket.io-parser@>=4.0.0 <4.2.7: ^4.2.7
   tmp@<0.2.6: ^0.2.6
   tmp@<=0.2.3: ^0.2.4
   ws@>=8.0.0 <8.20.1: ^8.20.1
@@ -1921,11 +1923,11 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -3421,8 +3423,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@25.0.1:
@@ -4413,8 +4415,8 @@ packages:
   socket.io-adapter@2.5.6:
     resolution: {integrity: sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==}
 
-  socket.io-parser@4.2.6:
-    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+  socket.io-parser@4.2.7:
+    resolution: {integrity: sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==}
     engines: {node: '>=10.0.0'}
 
   socket.io@4.8.3:
@@ -7753,12 +7755,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
@@ -9550,7 +9552,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -9818,15 +9820,15 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@8.0.7:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -10619,7 +10621,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.6(supports-color@10.2.2):
+  socket.io-parser@4.2.7(supports-color@10.2.2):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@10.2.2)
@@ -10634,7 +10636,7 @@ snapshots:
       debug: 4.4.3(supports-color@10.2.2)
       engine.io: 6.6.9(supports-color@10.2.2)
       socket.io-adapter: 2.5.6(supports-color@10.2.2)
-      socket.io-parser: 4.2.6(supports-color@10.2.2)
+      socket.io-parser: 4.2.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -10806,7 +10808,7 @@ snapshots:
       express: 5.2.1(supports-color@10.2.2)
       glob: 13.0.6
       http-proxy: 1.18.1(debug@4.4.3(supports-color@10.2.2))
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       minimatch: 10.2.6
       mkdirp: 3.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,9 +10,11 @@ autoInstallPeers: false
 
 overrides:
   '@babel/runtime@<7.26.10': ^7.26.10
-  brace-expansion@<1.1.16: ">=1.1.16 <2"
-  brace-expansion@>=2.0.0 <2.1.2: ">=2.1.2 <3"
+  brace-expansion@<1.1.18: ">=1.1.18 <2"
+  brace-expansion@>=2.0.0 <2.1.4: ">=2.1.4 <3"
   brace-expansion@>=3.0.0 <5.0.8: ">=5.0.8"
+  js-yaml@>=4.0.0 <4.3.1: ^4.3.1
+  socket.io-parser@>=4.0.0 <4.2.7: ^4.2.7
   tmp@<0.2.6: ^0.2.6
   tmp@<=0.2.3: ^0.2.4
   ws@>=8.0.0 <8.20.1: ^8.20.1


### PR DESCRIPTION
Closes all 6 open [Dependabot alerts](https://github.com/retailnext/ember-bem-helpers/security/dependabot). All of them are transitive dependencies reached only through `pnpm-lock.yaml`, so they're fixed the same way the existing ones in this repo are — by tightening the `overrides` block in `pnpm-workspace.yaml` and regenerating the lockfile.

| Alert | Severity | Package | Before | After |
|---|---|---|---|---|
| [#121](https://github.com/retailnext/ember-bem-helpers/security/dependabot/121) / [#118](https://github.com/retailnext/ember-bem-helpers/security/dependabot/118) | High | `brace-expansion` | 2.1.2 | 2.1.4 |
| [#120](https://github.com/retailnext/ember-bem-helpers/security/dependabot/120) / [#119](https://github.com/retailnext/ember-bem-helpers/security/dependabot/119) | High | `brace-expansion` | 1.1.16 | 1.1.18 |
| [#124](https://github.com/retailnext/ember-bem-helpers/security/dependabot/124) | High | `js-yaml` | 4.3.0 | 4.3.1 |
| [#123](https://github.com/retailnext/ember-bem-helpers/security/dependabot/123) | High | `socket.io-parser` | 4.2.6 | 4.2.7 |

Advisories: GHSA-mh99-v99m-4gvg and GHSA-rgw5-rvv9-x895 (`brace-expansion` ReDoS), GHSA-5p4m-2wfm-xmqj (`js-yaml`), GHSA-2m8v-j782-fhvr (`socket.io-parser`).

The `brace-expansion@>=3.0.0 <5.0.8` override is left as-is — the 5.x line already resolves to 5.0.8, which is not affected.

All patched versions are same-minor, so no breaking changes are expected.

## Verification

Run locally against the regenerated lockfile:

- `pnpm install` — clean
- `pnpm run build` — clean
- `pnpm run lint` — all 4 lint tasks pass (`hbs`, `js`, `types`, `publish`)
- `pnpm run test` — 19/19 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)